### PR TITLE
Heroエリアの背景画像の位置をセンターへ変更

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,6 +1,11 @@
 /*=================================================================
   Hero section
 ==================================================================*/
+.hero-area {
+    background-position: center center;
+    background-size: cover;
+}
+
 .hero-area .block {
     /* ref: https://github.com/oystersjp/oystersjp.github.io/issues/30 */
     width: 100%;

--- a/hugo/static/css/custom.css
+++ b/hugo/static/css/custom.css
@@ -1,6 +1,11 @@
 /*=================================================================
   Hero section
 ==================================================================*/
+.hero-area {
+    background-position: center center;
+    background-size: cover;
+}
+
 .hero-area .block {
     /* ref: https://github.com/oystersjp/oystersjp.github.io/issues/30 */
     width: 100%;


### PR DESCRIPTION
ピンショットに見えるので、写真中央が表示されるようにした。

### Before
![スクリーンショット 2020-09-16 22 20 29](https://user-images.githubusercontent.com/3056652/93342997-f0e54300-f86a-11ea-90e6-cfb75f61bf35.png)

### After
![スクリーンショット 2020-09-16 22 20 58](https://user-images.githubusercontent.com/3056652/93342987-ecb92580-f86a-11ea-90bb-9c99bc9e2660.png)