### PR TITLE
github actionsでhugoがbuildできていなかった

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
           hugo-version: '0.58.3'
 
       - name: Build
-        run: make build
+        run: make build HUGO=$(which hugo)
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
ref: #40 

# 内容

https://github.com/oystersjp/oystersjp.github.io/runs/1123956274?check_suite_focus=true

![image](https://user-images.githubusercontent.com/7962629/93363106-c2bf2d80-f881-11ea-8dbe-76a58058d1ee.png)

# 対応

github actionsのフローでhugoのインストールはしてるので、hugoのパスを `make build` の際に `HUGO` の変数に渡してやるようにする