### PR TITLE
SVG画像がproductionビルド時に壊れてしまう問題の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 HUGO = bin/hugo
 THEME = hugo/themes/meghna-hugo
-TARGET_VERSION = 0.58.3
+TARGET_VERSION = 0.78.0
 
 .PHONY: build watch
 build: $(HUGO) $(THEME)

--- a/hugo/assets/images/logo.svg
+++ b/hugo/assets/images/logo.svg
@@ -1,137 +1,29 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="336.45801"
-   height="71.414177"
-   viewBox="0 0 89.021182 18.894999"
-   version="1.1"
-   id="svg8"
-   inkscape:version="1.0.1 (c497b03c, 2020-09-10)"
-   sodipodi:docname="logotype.svg"
-   inkscape:export-filename="/Users/JP25375/Desktop/logotype.png"
-   inkscape:export-xdpi="142.66"
-   inkscape:export-ydpi="142.66">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#ffffff"
-     borderopacity="1"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.47509504"
-     inkscape:cx="465.09377"
-     inkscape:cy="156.24659"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     inkscape:document-rotation="0"
-     showgrid="false"
-     inkscape:window-width="1663"
-     inkscape:window-height="1174"
-     inkscape:window-x="586"
-     inkscape:window-y="94"
-     inkscape:window-maximized="0"
-     inkscape:pagecheckerboard="false"
-     inkscape:snap-page="true"
-     units="px"
-     borderlayer="false"
-     inkscape:showpageshadow="true"
-     objecttolerance="20"
-     guidetolerance="20"
-     gridtolerance="10"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     lock-margins="true" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="レイヤー 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-31.565178,-39.899526)">
-    <rect
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.12;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-       id="rect2541"
-       height="52.241486"
-       x="122.6683"
-       y="0"
-       width="0" />
-    <g
-       id="g2180-8"
-       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.28434;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(1.2007514,0,0,1.2723628,37.126831,16.318413)">
-      <path
-         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.28434;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-         d="M 0.27203501,32.715356 C -2.5124873,32.21864 -5.1263676,23.78703 -3.409486,20.839849 -1.6926024,17.892666 5.1246785,19.108766 6.1923193,22.552662 7.2599611,25.996559 3.0565584,33.212073 0.27203501,32.715356 Z"
-         id="path2310-8" />
-      <path
-         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.28434;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-         d="m 5.4067255,25.245604 c 0.754175,2.80928 -3.855723,8.474798 -5.78227699,7.286521 -1.72659101,-1.064942 -4.63621401,-7.250865 -2.63726701,-9.594908 1.764755,-2.069421 7.665368,-0.500891 8.419544,2.308387 z"
-         id="path2308-7"
-         sodipodi:nodetypes="ssss" />
-      <path
-         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.28434;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-         d="m 1.1835864,27.262482 c 0.5511862,1.238989 -0.96324272,4.74191 -1.88883084,4.80107 -0.52555426,0.03359 -2.60824576,-2.98826 -1.90064196,-4.272373 0.7197788,-1.306204 3.23828666,-1.767684 3.7894728,-0.528697 z"
-         id="path2306-1"
-         sodipodi:nodetypes="ssss" />
-      <path
-         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.28434;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-         d="M 3.69364,27.287947 C 4.5467866,30.428765 1.506811,33.195455 -0.44433699,32.414982 -2.1208337,31.744373 -3.8536024,26.768935 -2.5743124,25.063891 -1.3637412,23.450437 3.0287852,24.840319 3.69364,27.287947 Z"
-         id="path2137-6-0-9"
-         sodipodi:nodetypes="ssss" />
-    </g>
-    <g
-       id="g862-3"
-       transform="matrix(1.350965,0,0,1.3509624,23.983445,-19.653912)">
-      <path
-         d="m 18.589364,51.07538 q 0,1.67289 0.10038,2.26173 0.05349,0.31453 0.133831,0.52198 0.08698,0.20078 0.194039,0.42159 0.354632,0.67587 1.137559,1.1911 0.76953,0.53531 1.920474,0.56209 1.164325,-0.0271 1.940546,-0.56209 0.769527,-0.51523 1.110793,-1.1911 0.247572,-0.35466 0.341269,-0.9435 0.08698,-0.58882 0.08698,-2.26174 0,-1.699665 -0.08698,-2.275131 -0.0937,-0.575473 -0.341269,-0.930129 -0.34127,-0.675863 -1.110793,-1.204471 -0.776222,-0.535333 -1.940546,-0.548687 -1.150946,0.01352 -1.920474,0.548687 -0.782905,0.528656 -1.137559,1.204471 -0.220803,0.354664 -0.32791,0.930129 -0.10038,0.575474 -0.10038,2.275131 z m 1.485522,0 q 0,-1.438688 0.107062,-1.960628 0.0937,-0.495192 0.381436,-0.809675 0.234202,-0.301091 0.61562,-0.501871 0.374716,-0.194024 0.896667,-0.207457 0.528634,0.01352 0.916741,0.207457 0.368033,0.20078 0.588849,0.501871 0.287737,0.314522 0.394805,0.809675 0.10038,0.5219 0.10038,1.960628 0,1.43868 -0.10038,1.94725 -0.107063,0.50853 -0.394805,0.82304 -0.220801,0.30109 -0.588849,0.48851 -0.388119,0.22081 -0.916741,0.22081 -0.521941,0 -0.896667,-0.22081 -0.381434,-0.18734 -0.61562,-0.48851 -0.287738,-0.31453 -0.381436,-0.82304 -0.107062,-0.50857 -0.107062,-1.94725 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.45028;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2282-1" />
-      <path
-         d="m 28.832152,55.9535 h 1.391839 v -4.01492 l 2.937586,-5.741341 h -1.565822 l -2.067682,4.329431 v 0 l -2.067687,-4.329431 h -1.565818 l 2.937584,5.741341 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.45028;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2284-1" />
-      <path
-         d="m 34.234588,53.58472 -0.970269,1.11078 q 1.559128,1.33829 3.727182,1.33829 3.35246,-0.0405 3.426067,-2.8372 0,-1.03719 -0.649078,-1.82007 -0.65577,-0.79632 -2.027535,-0.98368 -0.69592,-0.087 -1.097411,-0.15388 -0.722684,-0.13385 -1.050569,-0.481767 -0.327907,-0.341232 -0.327907,-0.76282 0.01321,-0.70265 0.488482,-1.057266 0.455023,-0.34123 1.13756,-0.34123 1.318233,0.02703 2.415644,0.749467 v 0 l 0.823062,-1.217858 q -1.345004,-0.970277 -3.165101,-1.010424 -1.512285,0.01352 -2.335342,0.789607 -0.849827,0.782929 -0.849827,2.060998 0,1.063952 0.675845,1.806713 0.65577,0.72269 1.913778,0.93013 0.702614,0.10036 1.291467,0.18067 1.284778,0.2208 1.271396,1.31153 -0.0268,1.33163 -1.927168,1.35839 -1.605966,-0.0135 -2.770294,-0.97025 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.45028;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2286-4" />
-      <path
-         d="m 43.895232,55.9535 h 1.485521 v -8.43803 h 2.669924 v -1.318231 h -6.825369 v 1.318231 h 2.669924 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.45028;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2288-9" />
-      <path
-         d="m 49.223848,55.9535 h 6.22982 V 54.55498 H 50.702676 V 51.691 h 4.055074 v -1.31155 h -4.055074 v -2.783676 h 4.750992 v -1.398535 h -6.22982 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.45028;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2290-5" />
-      <path
-         d="m 58.330874,47.51547 h 2.315272 q 0.709302,0 1.08403,0.301089 0.475097,0.341231 0.488482,1.104108 0,0.635721 -0.408179,1.070642 -0.414874,0.468411 -1.244626,0.481761 h -2.234979 z m -1.478829,8.43803 h 1.478829 v -4.1688 h 1.887014 l 2.014149,4.1688 h 1.759881 l -2.261742,-4.32942 q 1.86025,-0.71601 1.887012,-2.703382 -0.04014,-1.351687 -0.970273,-2.081068 -0.76953,-0.642399 -1.987387,-0.642399 h -3.807483 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.45028;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2292-9" />
-      <path
-         d="m 65.323617,53.58454 -0.970268,1.11078 q 1.559128,1.33829 3.72718,1.33829 3.352461,-0.0397 3.426068,-2.8372 0,-1.03718 -0.649077,-1.82008 -0.655769,-0.79631 -2.027535,-0.98367 -0.695916,-0.087 -1.097411,-0.15389 -0.722688,-0.13385 -1.050571,-0.481761 -0.327868,-0.341309 -0.327868,-0.762818 0.0132,-0.702571 0.488483,-1.057267 0.45502,-0.34123 1.137559,-0.34123 1.318233,0.02702 2.415645,0.749468 v 0 l 0.823059,-1.217978 q -1.345001,-0.970276 -3.165098,-1.010424 -1.512287,0.01352 -2.335343,0.789607 -0.849828,0.782929 -0.849828,2.060998 0,1.063944 0.675847,1.806715 0.65577,0.72268 1.913781,0.93012 0.70261,0.10036 1.291466,0.18067 1.284777,0.2208 1.271395,1.31154 -0.02679,1.33162 -1.927165,1.35839 -1.605967,-0.0135 -2.770297,-0.97026 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.45028;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2294-0" />
-    </g>
+<svg width="336.46" height="71.414" version="1.1" viewBox="0 0 89.021 18.895" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g transform="translate(-31.565 -39.9)">
+  <rect x="122.67" width="0" height="52.241" fill="#fff" style="paint-order:normal"/>
+  <g transform="matrix(1.2008 0 0 1.2724 37.127 16.318)" fill="none" stroke="#fff" stroke-linecap="square" stroke-width="1.2843">
+   <path d="m0.27204 32.715c-2.7845-0.49672-5.3984-8.9283-3.6815-11.876 1.7169-2.9472 8.5342-1.7311 9.6018 1.7128 1.0676 3.4439-3.1358 10.659-5.9203 10.163z" style="paint-order:normal"/>
+   <path d="m5.4067 25.246c0.75418 2.8093-3.8557 8.4748-5.7823 7.2865-1.7266-1.0649-4.6362-7.2509-2.6373-9.5949 1.7648-2.0694 7.6654-0.50089 8.4195 2.3084z" style="paint-order:normal"/>
+   <path d="m1.1836 27.262c0.55119 1.239-0.96324 4.7419-1.8888 4.8011-0.52555 0.03359-2.6082-2.9883-1.9006-4.2724 0.71978-1.3062 3.2383-1.7677 3.7895-0.5287z" style="paint-order:normal"/>
+   <path d="m3.6936 27.288c0.85315 3.1408-2.1868 5.9075-4.138 5.127-1.6765-0.67061-3.4093-5.646-2.13-7.3511 1.2106-1.6135 5.6031-0.22357 6.268 2.2241z" style="paint-order:normal"/>
   </g>
+  <g transform="matrix(1.351 0 0 1.351 23.983 -19.654)" fill="#fff">
+   <path d="m18.589 51.075q0 1.6729 0.10038 2.2617 0.05349 0.31453 0.13383 0.52198 0.08698 0.20078 0.19404 0.42159 0.35463 0.67587 1.1376 1.1911 0.76953 0.53531 1.9205 0.56209 1.1643-0.0271 1.9405-0.56209 0.76953-0.51523 1.1108-1.1911 0.24757-0.35466 0.34127-0.9435 0.08698-0.58882 0.08698-2.2617 0-1.6997-0.08698-2.2751-0.0937-0.57547-0.34127-0.93013-0.34127-0.67586-1.1108-1.2045-0.77622-0.53533-1.9405-0.54869-1.1509 0.01352-1.9205 0.54869-0.7829 0.52866-1.1376 1.2045-0.2208 0.35466-0.32791 0.93013-0.10038 0.57547-0.10038 2.2751zm1.4855 0q0-1.4387 0.10706-1.9606 0.0937-0.49519 0.38144-0.80968 0.2342-0.30109 0.61562-0.50187 0.37472-0.19402 0.89667-0.20746 0.52863 0.01352 0.91674 0.20746 0.36803 0.20078 0.58885 0.50187 0.28774 0.31452 0.3948 0.80968 0.10038 0.5219 0.10038 1.9606 0 1.4387-0.10038 1.9472-0.10706 0.50853-0.3948 0.82304-0.2208 0.30109-0.58885 0.48851-0.38812 0.22081-0.91674 0.22081-0.52194 0-0.89667-0.22081-0.38143-0.18734-0.61562-0.48851-0.28774-0.31453-0.38144-0.82304-0.10706-0.50857-0.10706-1.9472z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+   <path d="m28.832 55.954h1.3918v-4.0149l2.9376-5.7413h-1.5658l-2.0677 4.3294-2.0677-4.3294h-1.5658l2.9376 5.7413z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+   <path d="m34.235 53.585-0.97027 1.1108q1.5591 1.3383 3.7272 1.3383 3.3525-0.0405 3.4261-2.8372 0-1.0372-0.64908-1.8201-0.65577-0.79632-2.0275-0.98368-0.69592-0.087-1.0974-0.15388-0.72268-0.13385-1.0506-0.48177-0.32791-0.34123-0.32791-0.76282 0.01321-0.70265 0.48848-1.0573 0.45502-0.34123 1.1376-0.34123 1.3182 0.02703 2.4156 0.74947l0.82306-1.2179q-1.345-0.97028-3.1651-1.0104-1.5123 0.01352-2.3353 0.78961-0.84983 0.78293-0.84983 2.061 0 1.064 0.67584 1.8067 0.65577 0.72269 1.9138 0.93013 0.70261 0.10036 1.2915 0.18067 1.2848 0.2208 1.2714 1.3115-0.0268 1.3316-1.9272 1.3584-1.606-0.0135-2.7703-0.97025z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+   <path d="m43.895 55.954h1.4855v-8.438h2.6699v-1.3182h-6.8254v1.3182h2.6699z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+   <path d="m49.224 55.954h6.2298v-1.3985h-4.751v-2.864h4.0551v-1.3116h-4.0551v-2.7837h4.751v-1.3985h-6.2298z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+   <path d="m58.331 47.515h2.3153q0.7093 0 1.084 0.30109 0.4751 0.34123 0.48848 1.1041 0 0.63572-0.40818 1.0706-0.41487 0.46841-1.2446 0.48176h-2.235zm-1.4788 8.438h1.4788v-4.1688h1.887l2.0141 4.1688h1.7599l-2.2617-4.3294q1.8602-0.71601 1.887-2.7034-0.04014-1.3517-0.97027-2.0811-0.76953-0.6424-1.9874-0.6424h-3.8075z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+   <path d="m65.324 53.585-0.97027 1.1108q1.5591 1.3383 3.7272 1.3383 3.3525-0.0397 3.4261-2.8372 0-1.0372-0.64908-1.8201-0.65577-0.79631-2.0275-0.98367-0.69592-0.087-1.0974-0.15389-0.72269-0.13385-1.0506-0.48176-0.32787-0.34131-0.32787-0.76282 0.0132-0.70257 0.48848-1.0573 0.45502-0.34123 1.1376-0.34123 1.3182 0.02702 2.4156 0.74947l0.82306-1.218q-1.345-0.97028-3.1651-1.0104-1.5123 0.01352-2.3353 0.78961-0.84983 0.78293-0.84983 2.061 0 1.0639 0.67585 1.8067 0.65577 0.72268 1.9138 0.93012 0.70261 0.10036 1.2915 0.18067 1.2848 0.2208 1.2714 1.3115-0.02679 1.3316-1.9272 1.3584-1.606-0.0135-2.7703-0.97026z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+  </g>
+ </g>
 </svg>

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -11,6 +11,9 @@ publishDir = "../public"
   category = "categories"
   tag = "tags"
 
+[minify]
+  disableSVG = true
+
 # Menu
 [menu]
     [[menu.nav]]


### PR DESCRIPTION
https://suihan74.github.io/posts/2020/08_04_00_escape_minifying/

- SVGのminifyを無効にした（そのためにHugoのバージョンアップが必要だったので最新バージョンにした）
- SVGを圧縮