### PR TITLE
feat: footer component

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,0 +1,33 @@
+import Logo from '@/components/Logo/Logo'
+import Link from 'next/link'
+
+const Footer: React.FC<{ logoText: string }> = (props) => {
+  const year = new Date().getFullYear()
+
+  return (
+    <footer id="footer" className="bg-one">
+      <div className="container">
+        <div className="row wow fadeInUp" data-wow-duration="500ms">
+          <div className="col-xl-12">
+            <div className="copyright text-center">
+              <p>
+                <a title={props.logoText}>
+                  <Link href="/">
+                    <Logo />
+                  </Link>
+                </a>
+              </p>
+              <p>
+                Design And Developed by{' '}
+                <a href="http://www.themefisher.com/"> Themefisher Team </a>.
+                Copyright &copy; {year}. All Rights Reserved.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+export default Footer

--- a/components/Footer/index.ts
+++ b/components/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from '@/components/Footer/Footer'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import { GetStaticProps } from 'next'
 import { Member } from '@/types/Member'
 import { getAllMembers } from '@/lib/members'
 import Hero from '@/components/Hero'
+import Footer from '../components/Footer/Footer'
 const organizationName = 'Oysters'
 const organizationDescription = '若手ものづくり集団 Oysters'
 const siteUrl = 'https://oystersjp.github.io'
@@ -51,6 +52,7 @@ export default function Home({ members }: { members: Member[] }): JSX.Element {
       <Navbar />
       <Hero />
       <MemberList members={members} />
+      <Footer logoText={organizationName} />
     </>
   )
 }


### PR DESCRIPTION
#95 
hugoの元のコード:
- https://github.com/oystersjp/oystersjp.github.io/blob/f306bde333a0d829b27c8a68773da2b09216d078/hugo/layouts/partials/footer.html

hugoのコードとの変更点: 
- copyright, copyrightURL をベタ書きに変更 
- social-icon divを削除
　- hugoがgenerateしたコードが要素0だったため
   - https://github.com/oystersjp/oystersjp.github.io/blob/8a01cc48b8fc8d65b1541aa6d6c723d3b4c9d6b8/hugo/layouts/partials/footer.html#L10 
   - https://github.com/oystersjp/oystersjp.github.io/blob/8a01cc48b8fc8d65b1541aa6d6c723d3b4c9d6b8/hugo/config.toml#L76
   -  configが存在していないのでulが展開されていない 
- 画像のlinkを<a href="hogehoge" / >からnext.linkの<Link href="hogehoge"/>へ変更
  - ページ遷移を行わないので高速
- Google Analyticsを削除
  - 使ってる？ 


ask:  
- ブートストラップ？のコピーライトをそのまま使ってるけど問題ないか？

netlify: 
- https://6053576e3fc29cde1da2b2ee--zealous-yalow-0137bf.netlify.app