### PR TITLE
feat: add contact section

### DIFF
--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -1,0 +1,36 @@
+const Contact: React.FC = () => (
+  <section
+    id="contact"
+    className="call-to-action section-sm bg-1 overly"
+    style={{ backgroundImage: "url('/images/content/bg.jpeg')" }}
+  >
+    <div className="container">
+      <div className="row">
+        <div className="col-lg-12 text-center">
+          <div className="call-to-action__content">
+            <h2 className="mb-4">Oystersの活動に興味がある方へ</h2>
+            <p className="mb-3">
+              有意義な交流が出来るように、エンジニアリングや個人開発にモチベーションがある人をご招待しています
+              <br />
+              興味がある方はメンバーの誰か、または{' '}
+              <a href="https://twitter.com/pinkumohikan">
+                <i className="tf-ion-social-twitter"></i>@pinkumohikan
+              </a>{' '}
+              へご連絡下さい
+            </p>
+            <a
+              href="https://twitter.com/pinkumohikan"
+              className="btn btn-main page-scroll text-lowercase"
+              target="_blank"
+              rel="noreferrer noreferrer"
+            >
+              <i className="tf-ion-social-twitter"></i>@pinkumohikan
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+)
+
+export default Contact

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -1,6 +1,5 @@
 const Contact: React.FC = () => (
   <section
-    id="contact"
     className="call-to-action section-sm bg-1 overly"
     style={{ backgroundImage: "url('/images/content/bg.jpeg')" }}
   >

--- a/components/Contact/index.ts
+++ b/components/Contact/index.ts
@@ -1,0 +1,1 @@
+export { default } from '@/components/Contact/Contact'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import { Member } from '@/types/Member'
 import { getAllMembers } from '@/lib/members'
 import Hero from '@/components/Hero'
 import Footer from '../components/Footer/Footer'
+import Contact from '@/components/Contact/Contact'
 const organizationName = 'Oysters'
 const organizationDescription = '若手ものづくり集団 Oysters'
 const siteUrl = 'https://oystersjp.github.io'
@@ -52,6 +53,7 @@ export default function Home({ members }: { members: Member[] }): JSX.Element {
       <Navbar />
       <Hero />
       <MemberList members={members} />
+      <Contact />
       <Footer logoText={organizationName} />
     </>
   )


### PR DESCRIPTION
#99

https://github.com/oystersjp/oystersjp.github.io/blob/master/hugo/layouts/partials/contact.html

このContactのsectinのリプレイス

レビューで確認したい箇所: 
既存のhugoのページではNavBarなどでid="contact"を指定している箇所がない。修正方針として
1. NavBarにコンタクトを追加する
1. idを削除する
1. リプレイス優先で一旦このまま

の3つが考えられるがどの対応が良いか

netlify: https://60602c9093d4fba3e59f6e94--zealous-yalow-0137bf.netlify.app