### PR TITLE
同じアンカーリンクを２回クリックした際に'/'に遷移していた問題を修正

### DIFF
--- a/hooks/useRouterScroll.ts
+++ b/hooks/useRouterScroll.ts
@@ -8,8 +8,10 @@ export const useRouterScroll = ({
 }: ScrollToOptions = {}): void => {
   const router = useRouter()
   useEffect(() => {
-    const handleHashChangeComplete = () => {
-      window.scrollTo({ left, top, behavior })
+    const handleHashChangeComplete = (url) => {
+      if (url === '/') {
+        window.scrollTo({ left, top, behavior })
+      }
     }
 
     router.events.on('hashChangeComplete', handleHashChangeComplete)


### PR DESCRIPTION
netlify: https://607ad6a9c7f1df51d56ae4a6--zealous-yalow-0137bf.netlify.app