### PR TITLE
update actions-netlify version

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm ci  
     - run: npm run build
       name: Run build
-    - uses: nwtgck/actions-netlify@v1.0     
+    - uses: nwtgck/actions-netlify@v1.2.3 
       name: deploy to netlify 
       with:
         publish-dir: './out'


### PR DESCRIPTION
close: #149

security update対応のためにactions-netlifyの依存ライブラリのバージョンを1.0から最新(1.2.3)へ更新しました。 

actions-netlifyはPRのcommit毎にbuild結果をnetrifyにdeployしてくれる便利なライブラリです。

<img width="705" alt="image" src="https://user-images.githubusercontent.com/26830741/162601542-31c4decb-b78d-479e-a63b-c615a044164e.png">
